### PR TITLE
Avoid fail when XML description is missing

### DIFF
--- a/de.philippkatz.knime.jsondocgen.application/META-INF/MANIFEST.MF
+++ b/de.philippkatz.knime.jsondocgen.application/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JSON node documentation generator
 Bundle-SymbolicName: de.philippkatz.knime.jsondocgen.application;singleton:=true
-Bundle-Version: 1.6.1.qualifier
+Bundle-Version: 1.6.2.qualifier
 Bundle-Vendor: Philipp Katz; Selenium Nodes
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.6.0,4.0.0)",

--- a/de.philippkatz.knime.jsondocgen.application/pom.xml
+++ b/de.philippkatz.knime.jsondocgen.application/pom.xml
@@ -4,7 +4,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>de.philippkatz.knime.jsondocgen.application</artifactId>
-  <version>1.6.1-SNAPSHOT</version>
+  <version>1.6.2-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <parent>

--- a/de.philippkatz.knime.jsondocgen.application/src/de/philippkatz/knime/jsondocgen/JsonNodeDocuGenerator.java
+++ b/de.philippkatz.knime.jsondocgen.application/src/de/philippkatz/knime/jsondocgen/JsonNodeDocuGenerator.java
@@ -362,13 +362,19 @@ public class JsonNodeDocuGenerator implements IApplication {
 				}
 			}
 
-			// create the JSON entry from the node XML description
 			NodeTemplate nodeTemplate = (NodeTemplate) current;
 			NodeFactory<? extends NodeModel> factory = nodeTemplate.createFactoryInstance();
 
-			Element xmlDescription = factory.getXMLDescription();
-			NodeDocBuilder builder = NodeDocJsonParser.parse(xmlDescription, new NodeDocBuilder());
+			NodeDocBuilder builder = new NodeDocBuilder();
 			builder.setId(current.getID());
+			builder.setName(current.getName());
+			
+			// get additional information from the node XML description
+			Element xmlDescription = factory.getXMLDescription();
+			if (xmlDescription != null) {
+				NodeDocJsonParser.parse(xmlDescription, builder);
+			}
+			
 			builder.setContributingPlugin(current.getContributingPlugin());
 			if (nodeTemplate.getIcon() != null) {
 				builder.setIconBase64(Utils.getImageBase64(nodeTemplate.getIcon()));

--- a/de.philippkatz.knime.jsondocgen.feature/feature.xml
+++ b/de.philippkatz.knime.jsondocgen.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
    id="de.philippkatz.knime.jsondocgen.feature"
    label="JSON node documentation generator"
-   version="1.6.1.qualifier"
+   version="1.6.2.qualifier"
    provider-name="seleniumnodes.com; Philipp Katz">
 
    <plugin

--- a/de.philippkatz.knime.jsondocgen.feature/pom.xml
+++ b/de.philippkatz.knime.jsondocgen.feature/pom.xml
@@ -4,7 +4,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>de.philippkatz.knime.jsondocgen.feature</artifactId>
-  <version>1.6.1-SNAPSHOT</version>
+  <version>1.6.2-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 
   <parent>


### PR DESCRIPTION
Obviously, there exists nodes that don't have a XML description. We saw this phenomena two weeks ago for the first time on the KNIME Trusted Community Contributions update site. This PR makes the node doc generator robust against missing descriptions.