### PR TITLE
Debugging crawler issues

### DIFF
--- a/de.philippkatz.knime.jsondocgen.application/META-INF/MANIFEST.MF
+++ b/de.philippkatz.knime.jsondocgen.application/META-INF/MANIFEST.MF
@@ -11,7 +11,8 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.6.0,4.0.0)",
  org.eclipse.equinox.p2.metadata;bundle-version="[2.3.100,3.0.0)",
  org.eclipse.equinox.p2.core;bundle-version="[2.4.100,3.0.0)",
  org.eclipse.equinox.p2.engine;bundle-version="[2.4.100,3.0.0)",
- org.knime.product;bundle-version="[3.0.0,4.0.0)"
+ org.knime.product;bundle-version="[3.0.0,4.0.0)",
+ org.apache.log4j;bundle-version="[1.2.0,2.0.0)"
 Bundle-ClassPath: .,
  lib/gson.jar
 Bundle-Activator: de.philippkatz.knime.jsondocgen.Activator

--- a/de.philippkatz.knime.jsondocgen.application/META-INF/MANIFEST.MF
+++ b/de.philippkatz.knime.jsondocgen.application/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JSON node documentation generator
 Bundle-SymbolicName: de.philippkatz.knime.jsondocgen.application;singleton:=true
-Bundle-Version: 1.7.0.qualifier
+Bundle-Version: 1.7.1.qualifier
 Bundle-Vendor: Philipp Katz; Selenium Nodes
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.6.0,4.0.0)",

--- a/de.philippkatz.knime.jsondocgen.application/pom.xml
+++ b/de.philippkatz.knime.jsondocgen.application/pom.xml
@@ -4,7 +4,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>de.philippkatz.knime.jsondocgen.application</artifactId>
-  <version>1.7.0-SNAPSHOT</version>
+  <version>1.7.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <parent>

--- a/de.philippkatz.knime.jsondocgen.application/src/de/philippkatz/knime/jsondocgen/JsonNodeDocuGenerator.java
+++ b/de.philippkatz.knime.jsondocgen.application/src/de/philippkatz/knime/jsondocgen/JsonNodeDocuGenerator.java
@@ -117,6 +117,9 @@ public class JsonNodeDocuGenerator implements IApplication {
 
 	private static final String SKIP_SPLASH_ICONS = "-skipSplashIcons";
 
+	/** Return code in case an error occurs during execution. */
+	private static final Integer EXIT_EXECUTION_ERROR = Integer.valueOf(1);
+
 	private static void printUsage() {
 		System.err.println("Usage: NodeDocuGenerator options");
 		System.err.println("Allowed options are:");
@@ -182,17 +185,23 @@ public class JsonNodeDocuGenerator implements IApplication {
 		if (m_directory == null) {
 			System.err.println("No output directory specified");
 			printUsage();
-			return 1;
+			return EXIT_EXECUTION_ERROR;
 		} else if (!m_directory.exists() && !m_directory.mkdirs()) {
 			System.err.println("Could not create output directory '" + m_directory.getAbsolutePath() + "'.");
-			return 1;
+			return EXIT_EXECUTION_ERROR;
 		}
 
 		try {
 			generate();
-		} catch (Exception e) {
-			LOGGER.error("Encountered error", e);
-			throw e;
+		} catch (Throwable t) {
+			// important: catch all throwables here and do not throw them out of this
+			// method; this is due to the fact, that execution errors are being shown in a
+			// GUI dialog, and when running headless (with Xvfb), we cannot access this
+			// dialog, the application will just remain running, and we will never know why
+			// we're hanging. Happy debugging! (nb: catching Throwable on purpose, Exception
+			// is not sufficient; we had a java.lang.NoClassDefFoundError)
+			LOGGER.error("Encountered error", t);
+			return EXIT_EXECUTION_ERROR;
 		}
 
 		return EXIT_OK;

--- a/de.philippkatz.knime.jsondocgen.application/src/de/philippkatz/knime/jsondocgen/JsonNodeDocuGenerator.java
+++ b/de.philippkatz.knime.jsondocgen.application/src/de/philippkatz/knime/jsondocgen/JsonNodeDocuGenerator.java
@@ -221,7 +221,7 @@ public class JsonNodeDocuGenerator implements IApplication {
 
 		if (!m_skipNodeDocumentation) {
 
-			System.out.println("Reading node repository");
+			LOGGER.info("Reading node repository");
 
 			IRepositoryObject root = RepositoryManager.INSTANCE.getRoot();
 			rootCategoryDoc = new CategoryDocBuilder();
@@ -242,14 +242,14 @@ public class JsonNodeDocuGenerator implements IApplication {
 			CategoryDoc rootCategory = rootCategoryDoc.build();
 			String resultJson = rootCategory.toJson();
 			File resultFile = new File(m_directory, "nodeDocumentation.json");
-			System.out.println("Writing nodes to " + resultFile);
+			LOGGER.info("Writing nodes to " + resultFile);
 			IOUtils.write(resultJson, new FileOutputStream(resultFile), StandardCharsets.UTF_8);
 
 		}
 
 		if (!m_skipPortDocumentation) {
 
-			LOGGER.debug("Generating port documentation");
+			LOGGER.info("Generating port documentation");
 
 			Map<Class<? extends PortObject>, PortTypeDocBuilder> builders = new HashMap<>();
 
@@ -267,7 +267,7 @@ public class JsonNodeDocuGenerator implements IApplication {
 			PortTypeDoc rootElement = builders.get(PortObject.class).build();
 
 			File portTypeResultFile = new File(m_directory, "portDocumentation.json");
-			System.out.println("Writing port types to " + portTypeResultFile);
+			LOGGER.info("Writing port types to " + portTypeResultFile);
 			IOUtils.write(Utils.toJson(rootElement), new FileOutputStream(portTypeResultFile), StandardCharsets.UTF_8);
 
 		}
@@ -280,7 +280,7 @@ public class JsonNodeDocuGenerator implements IApplication {
 			LOGGER.debug(String.format("Found %s splash icons", splashIcons.size()));
 
 			File splashIconsResultFile = new File(m_directory, "splashIcons.json");
-			System.out.println("Writing splash icons to " + splashIconsResultFile);
+			LOGGER.info("Writing splash icons to " + splashIconsResultFile);
 			IOUtils.write(Utils.toJson(splashIcons), new FileOutputStream(splashIconsResultFile),
 					StandardCharsets.UTF_8);
 		}
@@ -420,7 +420,7 @@ public class JsonNodeDocuGenerator implements IApplication {
 				builder.setInPorts(mergePortInfo(builder.build().inPorts, inPorts, current.getID()));
 				builder.setStreamable(isStreamable(nodeModel));
 			} catch (Throwable t) {
-				System.out.println(String.format("[warn] Could not create NodeModel for %s: %s", factory, t));
+				LOGGER.warn(String.format("Could not create NodeModel for %s", factory.getClass().getName()), t);
 			}
 
 			if (deprecated) {
@@ -434,7 +434,7 @@ public class JsonNodeDocuGenerator implements IApplication {
 
 			return true;
 		} else if (current instanceof Category || current instanceof Root) {
-			System.out.println("Processing category " + getPath(current));
+			LOGGER.info("Processing category " + getPath(current));
 			IRepositoryObject[] repoObjs = ((IContainerObject) current).getChildren();
 
 			CategoryDocBuilder newCategory = parentCategory;
@@ -490,8 +490,8 @@ public class JsonNodeDocuGenerator implements IApplication {
 		int numDocPorts = ports.size();
 		int numImplPorts = portTypes.length;
 		if (numDocPorts != numImplPorts) {
-			System.out.println(String.format("[warn] %s: Documentation does not match implementation: %s vs. %s ports",
-					nodeId, numDocPorts, numImplPorts));
+			LOGGER.warn(String.format("%s: Documentation does not match implementation: %s vs. %s ports", nodeId,
+					numDocPorts, numImplPorts));
 		}
 		for (int index = 0; index < numImplPorts; index++) {
 			PortType portType = portTypes[index];

--- a/de.philippkatz.knime.jsondocgen.feature/feature.xml
+++ b/de.philippkatz.knime.jsondocgen.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
    id="de.philippkatz.knime.jsondocgen.feature"
    label="JSON node documentation generator"
-   version="1.7.0.qualifier"
+   version="1.7.1.qualifier"
    provider-name="seleniumnodes.com; Philipp Katz">
 
    <plugin

--- a/de.philippkatz.knime.jsondocgen.feature/pom.xml
+++ b/de.philippkatz.knime.jsondocgen.feature/pom.xml
@@ -4,7 +4,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>de.philippkatz.knime.jsondocgen.feature</artifactId>
-  <version>1.7.0-SNAPSHOT</version>
+  <version>1.7.1-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 
   <parent>

--- a/de.philippkatz.knime.jsondocgen.parent/pom.xml
+++ b/de.philippkatz.knime.jsondocgen.parent/pom.xml
@@ -14,8 +14,8 @@
 
   <repositories>
     <repository>
-      <id>knime-3.3</id>
-      <url>http://update.knime.org/analytics-platform/3.3/</url>
+      <id>knime-3.7</id>
+      <url>http://update.knime.org/analytics-platform/3.7/</url>
       <layout>p2</layout>
     </repository>
   </repositories>
@@ -34,6 +34,13 @@
         <artifactId>target-platform-configuration</artifactId>
         <version>${tycho-version}</version>
         <configuration>
+          <target>
+            <artifact>
+              <groupId>de.philippkatz.knime.jsondocgen</groupId>
+              <artifactId>de.philippkatz.knime.jsondocgen.targetplatform</artifactId>
+              <version>1.0.0-SNAPSHOT</version>
+            </artifact>
+          </target>
           <environments>
             <environment>
              <os>linux</os>

--- a/de.philippkatz.knime.jsondocgen.targetplatform/de.philippkatz.knime.jsondocgen.targetplatform.target
+++ b/de.philippkatz.knime.jsondocgen.targetplatform/de.philippkatz.knime.jsondocgen.targetplatform.target
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?><target name="KNIME" sequenceNumber="1">
+<locations>
+  <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+    <unit id="org.eclipse.equinox.p2.user.ui.feature.group" version="0.0.0"/>
+    <unit id="org.knime.features.base.feature.group" version="0.0.0"/>
+    <unit id="org.knime.features.base.source.feature.group" version="0.0.0"/>
+    <repository location="http://update.knime.org/analytics-platform/3.7/"/>
+  </location>
+</locations>
+<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+  <launcherArgs>
+    <vmArgs>
+      -Xmx1024m
+      -server
+      -Dsun.java2d.d3d=false
+      -Dosgi.classloader.lock=classname
+      -XX:+UnlockDiagnosticVMOptions
+      -XX:+UnsyncloadClass
+      -Dknime.enable.fastload=true
+      -ea
+      -Dorg.eclipse.swt.internal.gtk.cairoGraphics=false
+      -Dorg.eclipse.swt.internal.gtk.useCairo=false
+      -Dorg.eclipse.swt.browser.IEVersion=10001
+    </vmArgs>
+  </launcherArgs>
+</target>

--- a/de.philippkatz.knime.jsondocgen.targetplatform/pom.xml
+++ b/de.philippkatz.knime.jsondocgen.targetplatform/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>de.philippkatz.knime.jsondocgen.targetplatform</artifactId>
+  <packaging>eclipse-target-definition</packaging>
+
+  <parent>
+    <groupId>de.philippkatz.knime.jsondocgen</groupId>
+    <artifactId>de.philippkatz.knime.jsondocgen.parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <relativePath>../de.philippkatz.knime.jsondocgen.parent</relativePath>
+  </parent>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
   </parent>
 
   <modules>
+    <module>de.philippkatz.knime.jsondocgen.targetplatform</module>
     <module>de.philippkatz.knime.jsondocgen.application</module>
     <module>de.philippkatz.knime.jsondocgen.application.tests</module>
     <module>de.philippkatz.knime.jsondocgen.feature</module>

--- a/readme.md
+++ b/readme.md
@@ -53,8 +53,13 @@ This example creates three JSON file in you home directory
 * `splashIcons.json`: list of all registered splash screen icons
 
 ```
-$ ./Knime -nosplash -application de.philippkatz.knime.jsondocgen.application.JsonNodeDocumentationGenerator -destination ~ -category /selenium
+$ ./Knime -nosplash --launcher.suppressErrors -application de.philippkatz.knime.jsondocgen.application.JsonNodeDocumentationGenerator -destination ~ -category /selenium
 ```
+
+When running within a headless environment (CI, Docker, …) with Xvfb, it’s
+highly advisable to add the option `--launcher.suppressErrors`. Otherwise,
+execution errors will lead to a seemingly hanging application, as the shown
+error dialog remains “invisible”.
 
 The generated `nodeDocumentation.json` JSON file’s structure looks as follows:
 


### PR DESCRIPTION
After many hours of debugging, here's the modifications to have proper error handling.

Note: I'm returning a non-success error code on purpose, so that we can properly propagate the error to our API. This means, that per default, Eclipse/KNIME will still try to show the mentioned error dialog. 

There are two options to make the container quit properly:

* do **not** return with an error code, but with `EXIT_OK`. Not cool 👎 
* launch the process with `--launcher.suppressErrors` 👍 