### PR TITLE
Lower logging verbosity from error to warn

### DIFF
--- a/de.philippkatz.knime.jsondocgen.application/src/de/philippkatz/knime/jsondocgen/JsonNodeDocuGenerator.java
+++ b/de.philippkatz.knime.jsondocgen.application/src/de/philippkatz/knime/jsondocgen/JsonNodeDocuGenerator.java
@@ -656,7 +656,7 @@ public class JsonNodeDocuGenerator implements IApplication {
 			}
 		} catch (NoSuchMethodException e) {
 			// this should never happen, as the method is implemented by the NodeModel class
-			LOGGER.error(String.format("No createStreamableOperator method in %s", nodeModel.getClass().getName()), e);
+			LOGGER.warn(String.format("No createStreamableOperator method in %s", nodeModel.getClass().getName()));
 		}
 		return false;
 	}
@@ -673,7 +673,7 @@ public class JsonNodeDocuGenerator implements IApplication {
 			method.setAccessible(true);
 			return (Optional<String>) method.invoke(nodeFactory);
 		} catch (ReflectiveOperationException | IllegalArgumentException e) {
-			LOGGER.error(String.format("Could not call getBundleName for %s", nodeFactory.getClass().getName()), e);
+			LOGGER.warn(String.format("Could not call getBundleName for %s: %s", nodeFactory.getClass().getName(), e.getMessage()));
 			return Optional.empty();
 		}
 	}


### PR DESCRIPTION
* there's nothing we can do about these exceptions, anyways, and they are treated as graceful as possible, so `error` doesn't make sense
* shorten log output and remove stacktrace
* closes #38