### PR TITLE
Catch and Log Another Exception from NodeFactory

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,8 +21,11 @@ jobs:
           path: ~/.m2
           key: 'm2-cache'
 
+      - name: Install Xvfb
+        run: sudo apt-get update && sudo apt-get install -y xvfb libgtk-3-0
+
       - name: Build
-        run: mvn -V -B clean install
+        run: xvfb-run -a mvn -V -B clean install
 
       - name: Publish to NodePit
         # https://stackoverflow.com/questions/58139406/only-run-job-on-specific-branch-with-github-actions

--- a/application/META-INF/MANIFEST.MF
+++ b/application/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JSON node documentation generator
 Bundle-SymbolicName: de.philippkatz.knime.jsondocgen.application;singleton:=true
-Bundle-Version: 1.16.0.qualifier
+Bundle-Version: 1.16.1.qualifier
 Bundle-Vendor: Philipp Katz; Selenium Nodes
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.6.0,5.0.0)",

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -4,13 +4,13 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>de.philippkatz.knime.jsondocgen.application</artifactId>
-  <version>1.16.0-SNAPSHOT</version>
+  <version>1.16.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <parent>
     <groupId>de.philippkatz.knime.jsondocgen</groupId>
     <artifactId>de.philippkatz.knime.jsondocgen</artifactId>
-    <version>1.16.0-SNAPSHOT</version>
+    <version>1.16.1-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/application/src/de/philippkatz/knime/jsondocgen/JsonNodeDocuGenerator.java
+++ b/application/src/de/philippkatz/knime/jsondocgen/JsonNodeDocuGenerator.java
@@ -464,8 +464,9 @@ public class JsonNodeDocuGenerator implements IApplication {
 	 *         been skipped
 	 */
 	@SuppressWarnings({ "restriction", "unchecked" })
-	private boolean generate(final IRepositoryObject current, final IRepositoryObject parent,
-			CategoryDocBuilder parentCategory, Set<String> hiddenNodeFactoryIds) throws TransformerException, Exception {
+	/* package */ boolean generate(final IRepositoryObject current, final IRepositoryObject parent,
+			CategoryDocBuilder parentCategory, Set<String> hiddenNodeFactoryIds)
+			throws TransformerException, Exception {
 
 		if (current instanceof NodeTemplate nodeTemplate) {
 
@@ -514,14 +515,14 @@ public class JsonNodeDocuGenerator implements IApplication {
 				List<DynamicPortGroup> dynamicOutPorts = getDynamicPorts(factory, PortDirection.Out);
 				builder.setDynamicInPorts(mergeDynamicPortInfo(builder.build().dynamicInPorts, dynamicInPorts, current.getID()));
 				builder.setDynamicOutPorts(mergeDynamicPortInfo(builder.build().dynamicOutPorts, dynamicOutPorts, current.getID()));
+
+				Node node = new Node((NodeFactory<NodeModel>) factory);
+				var nodeDescription = node.invokeGetNodeDescription();
+				builder.setKeywords(Arrays.asList(nodeDescription.getKeywords()));
+				builder.setSinceVersion(nodeDescription.getSinceVersion().map(v -> v.toString()).orElse(null));
 			} catch (Throwable t) {
 				LOGGER.warn(String.format("Could not create NodeModel for %s", factory.getClass().getName()), t);
 			}
-			
-			Node node = new Node((NodeFactory<NodeModel>) factory);
-			var nodeDescription = node.invokeGetNodeDescription();
-			builder.setKeywords(Arrays.asList(nodeDescription.getKeywords()));
-			builder.setSinceVersion(nodeDescription.getSinceVersion().map(v -> v.toString()).orElse(null));
 
 			builder.setHasModernDialog(hasModernDialog(factory));
 			// since KNIME 5.5; https://github.com/knime/knime-core-ui/commit/8769e99ab4df0a435fb90936d664fdc6c6ac2b6d

--- a/application/src/de/philippkatz/knime/jsondocgen/docs/CategoryDoc.java
+++ b/application/src/de/philippkatz/knime/jsondocgen/docs/CategoryDoc.java
@@ -59,5 +59,9 @@ public final class CategoryDoc extends AbstractDoc {
 		}
 		return result;
 	}
+	
+	public List<NodeDoc> getNodes() {
+		return nodes;
+	}
 
 }

--- a/feature/feature.xml
+++ b/feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
    id="de.philippkatz.knime.jsondocgen.feature"
    label="NodePit JSON Documentation Generator"
-   version="1.16.0.qualifier"
+   version="1.16.1.qualifier"
    provider-name="seleniumnodes.com; Philipp Katz">
 
    <plugin

--- a/feature/pom.xml
+++ b/feature/pom.xml
@@ -4,13 +4,13 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>de.philippkatz.knime.jsondocgen.feature</artifactId>
-  <version>1.16.0-SNAPSHOT</version>
+  <version>1.16.1-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 
   <parent>
     <groupId>de.philippkatz.knime.jsondocgen</groupId>
     <artifactId>de.philippkatz.knime.jsondocgen</artifactId>
-    <version>1.16.0-SNAPSHOT</version>
+    <version>1.16.1-SNAPSHOT</version>
   </parent>
 
 </project>

--- a/p2/pom.xml
+++ b/p2/pom.xml
@@ -4,13 +4,13 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>de.philippkatz.knime.jsondocgen.p2</artifactId>
-  <version>1.16.0-SNAPSHOT</version>
+  <version>1.16.1-SNAPSHOT</version>
   <packaging>eclipse-repository</packaging>
 
   <parent>
     <groupId>de.philippkatz.knime.jsondocgen</groupId>
     <artifactId>de.philippkatz.knime.jsondocgen</artifactId>
-    <version>1.16.0-SNAPSHOT</version>
+    <version>1.16.1-SNAPSHOT</version>
   </parent>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
   </modules>
 
   <properties>
+    <eclipserun.jvm.flags/>
     <tycho-version>4.0.8</tycho-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
@@ -86,5 +87,19 @@
       </plugin>
     </plugins>
   </build>
+
+	<profiles>
+		<profile>
+			<id>macosx-jvm-flags</id>
+			<activation>
+				<os>
+					<family>mac</family>
+				</os>
+			</activation>
+			<properties>
+				<eclipserun.jvm.flags>-XstartOnFirstThread</eclipserun.jvm.flags>
+			</properties>
+		</profile>
+	</profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>de.philippkatz.knime.jsondocgen</groupId>
   <artifactId>de.philippkatz.knime.jsondocgen</artifactId>
-  <version>1.16.0-SNAPSHOT</version>
+  <version>1.16.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>
@@ -40,7 +40,7 @@
             <artifact>
               <groupId>de.philippkatz.knime.jsondocgen</groupId>
               <artifactId>de.philippkatz.knime.jsondocgen.targetplatform</artifactId>
-              <version>1.16.0-SNAPSHOT</version>
+              <version>1.16.1-SNAPSHOT</version>
             </artifact>
           </target>
           <environments>

--- a/targetplatform/pom.xml
+++ b/targetplatform/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>de.philippkatz.knime.jsondocgen</groupId>
     <artifactId>de.philippkatz.knime.jsondocgen</artifactId>
-    <version>1.16.0-SNAPSHOT</version>
+    <version>1.16.1-SNAPSHOT</version>
   </parent>
 
 </project>

--- a/tests/META-INF/MANIFEST.MF
+++ b/tests/META-INF/MANIFEST.MF
@@ -2,8 +2,8 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JSON node documentation generator tests
 Bundle-SymbolicName: de.philippkatz.knime.jsondocgen.tests;singleton:=true
-Bundle-Version: 1.16.0.qualifier
+Bundle-Version: 1.16.1.qualifier
 Bundle-Vendor: Philipp Katz; Selenium Nodes
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Fragment-Host: de.philippkatz.knime.jsondocgen.application;bundle-version="1.16.0"
+Fragment-Host: de.philippkatz.knime.jsondocgen.application;bundle-version="1.16.1"
 Require-Bundle: org.junit;bundle-version="4.12.0"

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -31,6 +31,14 @@
           </dependency-resolution>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-surefire-plugin</artifactId>
+        <version>${tycho-version}</version>
+        <configuration>
+          <argLine>${eclipserun.jvm.flags}</argLine>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -4,13 +4,13 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>de.philippkatz.knime.jsondocgen.tests</artifactId>
-  <version>1.16.0-SNAPSHOT</version>
+  <version>1.16.1-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <parent>
     <groupId>de.philippkatz.knime.jsondocgen</groupId>
     <artifactId>de.philippkatz.knime.jsondocgen</artifactId>
-    <version>1.16.0-SNAPSHOT</version>
+    <version>1.16.1-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/tests/src/de/philippkatz/knime/jsondocgen/JsonNodeDocuGeneratorTest_NoClassDefFound_Test.java
+++ b/tests/src/de/philippkatz/knime/jsondocgen/JsonNodeDocuGeneratorTest_NoClassDefFound_Test.java
@@ -1,0 +1,75 @@
+package de.philippkatz.knime.jsondocgen;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+
+import javax.xml.transform.TransformerException;
+
+import org.junit.Test;
+import org.knime.core.node.NodeDialogPane;
+import org.knime.core.node.NodeFactory;
+import org.knime.core.node.NodeModel;
+import org.knime.core.node.NodeView;
+import org.knime.core.node.NodeFactory.NodeType;
+import org.knime.workbench.repository.RepositoryManager;
+import org.knime.workbench.repository.model.DefaultNodeTemplate;
+import org.knime.workbench.repository.model.IRepositoryObject;
+
+import de.philippkatz.knime.jsondocgen.docs.CategoryDoc.CategoryDocBuilder;
+
+public class JsonNodeDocuGeneratorTest_NoClassDefFound_Test {
+
+	public static class MyNodeFactory extends NodeFactory<NodeModel> {
+
+		@Override
+		public NodeModel createNodeModel() {
+			throw new NoClassDefFoundError("org/RDKit/ROMol");
+		}
+
+		@Override
+		protected int getNrNodeViews() {
+			return 0;
+		}
+
+		@Override
+		public NodeView<NodeModel> createNodeView(int viewIndex, NodeModel nodeModel) {
+			return null;
+		}
+
+		@Override
+		protected boolean hasDialog() {
+			return false;
+		}
+
+		@Override
+		protected NodeDialogPane createNodeDialogPane() {
+			return null;
+		}
+
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void test() throws TransformerException, Exception {
+		var parentCategory = new CategoryDocBuilder();
+		var parent = RepositoryManager.INSTANCE.getRoot();
+		NodeFactory<NodeModel> factory = new MyNodeFactory();
+		var current = new DefaultNodeTemplate( //
+				(Class<NodeFactory<? extends NodeModel>>) factory.getClass(), //
+				"Bad Node", //
+				"de.philippkatz.knime.nodes.plugin", //
+				"/", //
+				NodeType.Other);
+
+		var result = new JsonNodeDocuGenerator().generate(current, parent, parentCategory, Collections.emptySet());
+
+		assertTrue(result);
+
+		var nodes = parentCategory.build().getNodes();
+		assertEquals(1, nodes.size());
+		assertEquals("Bad Node", nodes.get(0).name);
+	}
+
+}


### PR DESCRIPTION
As of today, some nodes of the Erlwood Nodes on KNIME 5.8 throw an exception when initiating the node model:

```
08:55:05.309 [main] ERROR JsonNodeDocuGenerator:246 - Encountered error
java.lang.NoClassDefFoundError: org/RDKit/ROMol
        at org.erlwood.knime.nodes.mmp.RDKitMMPNodeFactory.createNodeModel(RDKitMMPNodeFactory.java:41)
        at org.erlwood.knime.nodes.mmp.RDKitMMPNodeFactory.createNodeModel(RDKitMMPNodeFactory.java:1)
        at org.knime.core.node.NodeFactory.callCreateNodeModel(NodeFactory.java:565)
        at org.knime.core.node.Node.<init>(Node.java:307)
        at org.knime.core.node.Node.<init>(Node.java:279)
        at de.philippkatz.knime.jsondocgen.JsonNodeDocuGenerator.generate(JsonNodeDocuGenerator.java:521)
```

This PR catches and logs said exceptions – as we already did previously at another occurrence.

Running the new tests requires `XstartOnFirstThread` (on Mac) and `Xvfb` (during build). 